### PR TITLE
Fixing issue with unable to clear previously set description

### DIFF
--- a/library/eos_ethernet.py
+++ b/library/eos_ethernet.py
@@ -423,7 +423,10 @@ def set_description(module):
     name = module.attributes['name']
     module.log('Invoked set_description for eos_ethernet[%s] '
                'with value %s' % (name, value))
-    module.node.api('interfaces').set_description(name, value)
+    if value == '':
+        module.node.api('interfaces').set_description(name, default=True)
+    else:
+        module.node.api('interfaces').set_description(name, value)
 
 def set_enable(module):
     """ Configures the enable attribute for the interface

--- a/library/eos_interface.py
+++ b/library/eos_interface.py
@@ -401,7 +401,10 @@ def set_description(module):
     value = module.attributes['description']
     module.log('Invoked set_description for eos_interface[%s] '
                'with value %s' % (name, value))
-    module.node.api('interfaces').set_description(name, value)
+    if value == '':
+        module.node.api('interfaces').set_description(name, default=True)
+    else:
+        module.node.api('interfaces').set_description(name, value)
 
 def set_enable(module):
     """Configures the enable attribute for the interface

--- a/library/eos_portchannel.py
+++ b/library/eos_portchannel.py
@@ -436,7 +436,10 @@ def set_description(module):
     name = module.attributes['name']
     module.log('Invoked set_description for eos_portchannel[%s] '
                'with value %s' % (name, value))
-    module.node.api('interfaces').set_description(name, value)
+    if value == '':
+        module.node.api('interfaces').set_description(name, default=True)
+    else:
+        module.node.api('interfaces').set_description(name, value)
 
 def set_enable(module):
     """ Configures the enable attribute for the interface

--- a/library/eos_vxlan.py
+++ b/library/eos_vxlan.py
@@ -441,7 +441,10 @@ def set_description(module):
     name = module.attributes['name']
     module.log('Invoked set_description for eos_vxlan[%s] '
                'with value %s' % (name, value))
-    module.node.api('interfaces').set_description(name, value)
+    if value == '':
+        module.node.api('interfaces').set_description(name, default=True)
+    else:
+        module.node.api('interfaces').set_description(name, value)
 
 def set_enable(module):
     """ Configures the enable attribute for the interface


### PR DESCRIPTION
I am able to properly set an interface description using:

eos_interface: name=Ethernet3 description="test123"

but I am not able to clear the description, I tried doing the following:

eos_interface: name=Ethernet3 description=""

This would execute, but the description would not get cleared (it would actually say a change occurred at the Ansible execution level, but nothing changed). Looking at pyeapi/interfaces.py it looks like the set_description call requires the use of default=True.

I did not see another way to clear the interface description.

Consequently, I updated it to detect a null string for the description value and change the pyeapi call appropriately. I tested this on the eos_interface module and it worked properly.

It looked like eos_ethernet.py, eos_vxlan.py, and eos_portchannel.py also had the same exact mechanism for updating an interface description. 

Note, I did not change the module.log so it will say "with value  " (i.e. value <blank>) in the log file.

    module.log('Invoked set_description for eos_interface[%s] '
               'with value %s' % (name, value))