### PR TITLE
Added encoding option to command module.

### DIFF
--- a/library/eos_command.py
+++ b/library/eos_command.py
@@ -60,6 +60,14 @@ options:
     choices: []
     aliases: []
     version_added: 1.0.0
+  encoding:
+    description:
+      - Specifies the requested encoding of the command output.
+    required: false
+    default: json
+    choices: ['json','text']
+    aliases: []
+    version_added: 1.0.0
 """
 
 EXAMPLES = """
@@ -361,7 +369,8 @@ class EosAnsibleModule(AnsibleModule):
 
 def run_commands(module):
     commands = module.attributes['commands'].split(',')
-    return module.node.enable(commands)
+    encoding = module.attributes['encoding']
+    return module.node.enable(commands,encoding=encoding)
 
 def main():
     """ The main module routine called when the module is run by Ansible
@@ -369,6 +378,7 @@ def main():
 
     argument_spec = dict(
         commands=dict(required=True),
+        encoding=dict(required=False, default='json'),
     )
 
     module = EosAnsibleModule(argument_spec=argument_spec,


### PR DESCRIPTION
When performing tasks like creating a snapshot of device configs in a lab (e.g. to automate switching between different topologies), the json structure is difficult to render into a readable configuration.

e.g. With multiple nested levels, the structure isn't ordered, so you end up with something like this:

```json
{ "management api http-commands": {
                                "cmds": {
                                    "vrf MGMT": {
                                        "cmds": {
                                            "no shutdown": null
                                        }, 
                                        "comments": []
                                    },
                                    "no shutdown": null, 
                                    "no protocol https": null, 
                                    "protocol http": null, 
                                }, 
                                "comments": []
                            }
}
```

which results in:
```
management api http-commands
  vrf MGMT
    no shutdown
  no shutdown
  no protocol https
  protocol http
```

without adding a lot of complex code that has prior knowledge of what the ordering **should** be.