### PR TITLE
Workaround for Ansible 2.0 changes in AnsibleModule._log_invocation().

### DIFF
--- a/common/eos.py
+++ b/common/eos.py
@@ -85,6 +85,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then 
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule) 
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in 
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -320,7 +338,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY


### PR DESCRIPTION
Ansible 2.0 introduced some changes that were causing my Arista modules to fail.

I found two issues:
1. `AnsibleModule.__init__()` calls `self._log_invocation()`, which (new to 2.0) calls `self.log(msg,log_args=log_args)`. 
    However, `EosAnsibleModule` overrides `self.log()` and doesn't accept the `log_args` kwarg.
2. The `EosAnsibleModule.log()` makes reference to `self._logging`, the definition of which references `self.params`, which is defined in `AnsibleModule.__init__()` [which, calls self.log()].

To get around the circular issue, I predefined `self._logging` **before** `AnsibleModule.__init__()`, but without the `or self.params['logging']` (which is reintroduced when `self._logging` is redefined later).

I solved it this way to try to minimize the changes to the base code.

For the pull request, I put this in common/eos.py instead of (every single) module in case you would prefer to solve this through some other method.  Either way, I mostly just wanted to bring this issue to your attention.