### PR TITLE
Enhance autorefresh

### DIFF
--- a/common/eos.py
+++ b/common/eos.py
@@ -187,6 +187,8 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
                 self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()

--- a/common/eos.py
+++ b/common/eos.py
@@ -189,7 +189,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -202,6 +202,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -219,7 +220,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/common/eos.py
+++ b/common/eos.py
@@ -268,7 +268,7 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        self.log('Creating connection with auto: %s' % self._autorefresh)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
         node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
                                   **config)
 

--- a/common/eos.py
+++ b/common/eos.py
@@ -202,7 +202,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -220,6 +219,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_acl_entry.py
+++ b/library/eos_acl_entry.py
@@ -321,7 +321,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -339,6 +338,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_acl_entry.py
+++ b/library/eos_acl_entry.py
@@ -308,7 +308,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -321,6 +321,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -338,7 +339,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_acl_entry.py
+++ b/library/eos_acl_entry.py
@@ -134,6 +134,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -152,7 +196,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -175,6 +219,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -205,9 +252,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -262,6 +306,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -340,7 +387,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_bgp_config.py
+++ b/library/eos_bgp_config.py
@@ -311,7 +311,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -324,6 +324,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -341,7 +342,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()
@@ -506,6 +508,7 @@ def set_router_id(module):
     module.log('Invoked set_router_id for eos_bgp_config[{}] '
                'with value {}'.format(bgp_as, value))
     module.node.api('bgp').set_router_id(value)
+    module.log('Ran command')
 
 def set_maximum_paths(module):
     """Configures the BGP maximum-paths

--- a/library/eos_bgp_config.py
+++ b/library/eos_bgp_config.py
@@ -324,7 +324,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -342,6 +341,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_bgp_config.py
+++ b/library/eos_bgp_config.py
@@ -137,6 +137,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -155,7 +199,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -178,6 +222,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -208,9 +255,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -265,6 +309,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -343,7 +390,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_bgp_neighbor.py
+++ b/library/eos_bgp_neighbor.py
@@ -161,6 +161,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -179,7 +223,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -202,6 +246,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -232,9 +279,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -289,6 +333,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -367,7 +414,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_bgp_neighbor.py
+++ b/library/eos_bgp_neighbor.py
@@ -335,7 +335,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -348,6 +348,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -365,7 +366,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_bgp_neighbor.py
+++ b/library/eos_bgp_neighbor.py
@@ -348,7 +348,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -366,6 +365,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_bgp_network.py
+++ b/library/eos_bgp_network.py
@@ -289,7 +289,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -307,6 +306,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_bgp_network.py
+++ b/library/eos_bgp_network.py
@@ -276,7 +276,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -289,6 +289,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -306,7 +307,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_bgp_network.py
+++ b/library/eos_bgp_network.py
@@ -102,6 +102,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -120,7 +164,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -143,6 +187,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -173,9 +220,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -230,6 +274,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -308,7 +355,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_command.py
+++ b/library/eos_command.py
@@ -267,7 +267,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -280,6 +280,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -297,7 +298,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_command.py
+++ b/library/eos_command.py
@@ -280,7 +280,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -298,6 +297,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_command.py
+++ b/library/eos_command.py
@@ -93,6 +93,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -111,7 +155,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -134,6 +178,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -164,9 +211,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -221,6 +265,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -299,7 +346,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_config.py
+++ b/library/eos_config.py
@@ -301,7 +301,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -314,6 +314,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -331,7 +332,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_config.py
+++ b/library/eos_config.py
@@ -314,7 +314,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -332,6 +331,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_config.py
+++ b/library/eos_config.py
@@ -127,6 +127,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -145,7 +189,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -168,6 +212,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -198,9 +245,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -255,6 +299,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -333,7 +380,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_ethernet.py
+++ b/library/eos_ethernet.py
@@ -313,7 +313,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -326,6 +326,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -343,7 +344,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_ethernet.py
+++ b/library/eos_ethernet.py
@@ -139,6 +139,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -157,7 +201,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -180,6 +224,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -210,9 +257,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -267,6 +311,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -345,7 +392,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_ethernet.py
+++ b/library/eos_ethernet.py
@@ -326,7 +326,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -344,6 +343,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_facts.py
+++ b/library/eos_facts.py
@@ -103,6 +103,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -121,7 +165,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -144,6 +188,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -174,9 +221,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -231,6 +275,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -309,7 +356,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_facts.py
+++ b/library/eos_facts.py
@@ -277,7 +277,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -290,6 +290,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -307,7 +308,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_facts.py
+++ b/library/eos_facts.py
@@ -290,7 +290,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -308,6 +307,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_interface.py
+++ b/library/eos_interface.py
@@ -280,7 +280,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -293,6 +293,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -310,7 +311,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_interface.py
+++ b/library/eos_interface.py
@@ -293,7 +293,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -311,6 +310,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_interface.py
+++ b/library/eos_interface.py
@@ -106,6 +106,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -124,7 +168,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -147,6 +191,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -177,9 +224,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -234,6 +278,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -312,7 +359,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_ipinterface.py
+++ b/library/eos_ipinterface.py
@@ -298,7 +298,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -316,6 +315,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_ipinterface.py
+++ b/library/eos_ipinterface.py
@@ -285,7 +285,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -298,6 +298,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -315,7 +316,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_ipinterface.py
+++ b/library/eos_ipinterface.py
@@ -111,6 +111,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -129,7 +173,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -152,6 +196,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -182,9 +229,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -239,6 +283,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -317,7 +364,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_mlag_config.py
+++ b/library/eos_mlag_config.py
@@ -302,7 +302,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -315,6 +315,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -332,7 +333,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_mlag_config.py
+++ b/library/eos_mlag_config.py
@@ -128,6 +128,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -146,7 +190,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -169,6 +213,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -199,9 +246,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -256,6 +300,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -334,7 +381,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -400,7 +449,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """Returns an instance of Mlag global config from the node

--- a/library/eos_mlag_config.py
+++ b/library/eos_mlag_config.py
@@ -315,7 +315,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -333,6 +332,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_mlag_interface.py
+++ b/library/eos_mlag_interface.py
@@ -97,6 +97,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -115,7 +159,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -138,6 +182,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -168,9 +215,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -225,6 +269,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -303,7 +350,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_mlag_interface.py
+++ b/library/eos_mlag_interface.py
@@ -284,7 +284,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -302,6 +301,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_mlag_interface.py
+++ b/library/eos_mlag_interface.py
@@ -271,7 +271,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -284,6 +284,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -301,7 +302,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_ping.py
+++ b/library/eos_ping.py
@@ -280,7 +280,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -293,6 +293,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -310,7 +311,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_ping.py
+++ b/library/eos_ping.py
@@ -293,7 +293,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -311,6 +310,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_ping.py
+++ b/library/eos_ping.py
@@ -106,6 +106,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -124,7 +168,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -147,6 +191,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -177,9 +224,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -234,6 +278,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -312,7 +359,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_portchannel.py
+++ b/library/eos_portchannel.py
@@ -138,6 +138,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -156,7 +200,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -179,6 +223,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -209,9 +256,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -266,6 +310,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -344,7 +391,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_portchannel.py
+++ b/library/eos_portchannel.py
@@ -312,7 +312,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -325,6 +325,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -342,7 +343,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_portchannel.py
+++ b/library/eos_portchannel.py
@@ -325,7 +325,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -343,6 +342,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_portchannel.py
+++ b/library/eos_portchannel.py
@@ -504,7 +504,8 @@ def main():
     )
 
     module = EosAnsibleModule(argument_spec=argument_spec,
-                              supports_check_mode=True)
+                              supports_check_mode=True,
+                              autorefresh=True)
 
     module.flush(True)
 

--- a/library/eos_purge.py
+++ b/library/eos_purge.py
@@ -109,6 +109,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -127,7 +171,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -150,6 +194,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -180,9 +227,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -237,6 +281,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -315,7 +362,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_purge.py
+++ b/library/eos_purge.py
@@ -296,7 +296,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -314,6 +313,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_purge.py
+++ b/library/eos_purge.py
@@ -283,7 +283,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -296,6 +296,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -313,7 +314,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_routemap.py
+++ b/library/eos_routemap.py
@@ -310,7 +310,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -323,6 +323,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -340,7 +341,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_routemap.py
+++ b/library/eos_routemap.py
@@ -323,7 +323,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -341,6 +340,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_routemap.py
+++ b/library/eos_routemap.py
@@ -136,6 +136,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -154,7 +198,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -177,6 +221,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -207,9 +254,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -264,6 +308,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -342,7 +389,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -408,7 +457,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """ Returns an instance of Routemaps based on name, action and sequence

--- a/library/eos_staticroute.py
+++ b/library/eos_staticroute.py
@@ -117,6 +117,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -135,7 +179,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -158,6 +202,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -188,9 +235,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -245,6 +289,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -323,7 +370,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -389,7 +438,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """ Returns an instance of StaticRoute

--- a/library/eos_staticroute.py
+++ b/library/eos_staticroute.py
@@ -304,7 +304,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -322,6 +321,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_staticroute.py
+++ b/library/eos_staticroute.py
@@ -291,7 +291,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -304,6 +304,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -321,7 +322,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_stp_interface.py
+++ b/library/eos_stp_interface.py
@@ -306,7 +306,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -324,6 +323,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_stp_interface.py
+++ b/library/eos_stp_interface.py
@@ -119,6 +119,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -137,7 +181,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -160,6 +204,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -190,9 +237,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -247,6 +291,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -325,7 +372,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_stp_interface.py
+++ b/library/eos_stp_interface.py
@@ -293,7 +293,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -306,6 +306,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -323,7 +324,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_switchport.py
+++ b/library/eos_switchport.py
@@ -340,7 +340,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -358,6 +357,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_switchport.py
+++ b/library/eos_switchport.py
@@ -327,7 +327,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -340,6 +340,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -357,7 +358,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_switchport.py
+++ b/library/eos_switchport.py
@@ -153,6 +153,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -171,7 +215,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -194,6 +238,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -224,9 +271,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -281,6 +325,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -359,7 +406,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_system.py
+++ b/library/eos_system.py
@@ -267,7 +267,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -280,6 +280,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -297,7 +298,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_system.py
+++ b/library/eos_system.py
@@ -280,7 +280,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -298,6 +297,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_system.py
+++ b/library/eos_system.py
@@ -93,6 +93,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -111,7 +155,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -134,6 +178,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -164,9 +211,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -221,6 +265,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -299,7 +346,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_user.py
+++ b/library/eos_user.py
@@ -358,7 +358,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -376,6 +375,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_user.py
+++ b/library/eos_user.py
@@ -345,7 +345,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -358,6 +358,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -375,7 +376,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_varp.py
+++ b/library/eos_varp.py
@@ -79,6 +79,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -97,7 +141,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -120,6 +164,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -150,9 +197,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -207,6 +251,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -285,7 +332,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -351,7 +400,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """ Returns an instance of Varp which includes the global mac-address. The

--- a/library/eos_varp.py
+++ b/library/eos_varp.py
@@ -253,7 +253,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -266,6 +266,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -283,7 +284,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_varp.py
+++ b/library/eos_varp.py
@@ -266,7 +266,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -284,6 +283,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_varp_interface.py
+++ b/library/eos_varp_interface.py
@@ -93,6 +93,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -111,7 +155,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -134,6 +178,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -164,9 +211,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -221,6 +265,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -299,7 +346,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -365,7 +414,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """ Returns an instance of Varp which includes the global mac-address. The

--- a/library/eos_varp_interface.py
+++ b/library/eos_varp_interface.py
@@ -267,7 +267,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -280,6 +280,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -297,7 +298,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_varp_interface.py
+++ b/library/eos_varp_interface.py
@@ -280,7 +280,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -298,6 +297,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_vlan.py
+++ b/library/eos_vlan.py
@@ -120,6 +120,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -138,7 +182,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -161,6 +205,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -191,9 +238,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -248,6 +292,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -326,7 +373,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -392,7 +441,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """ Returns an instance of Vlan based on vlanid

--- a/library/eos_vlan.py
+++ b/library/eos_vlan.py
@@ -294,7 +294,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -307,6 +307,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -324,7 +325,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_vlan.py
+++ b/library/eos_vlan.py
@@ -307,7 +307,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -325,6 +324,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_vrrp.py
+++ b/library/eos_vrrp.py
@@ -408,7 +408,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -426,6 +425,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_vrrp.py
+++ b/library/eos_vrrp.py
@@ -395,7 +395,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -408,6 +408,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -425,7 +426,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_vrrp.py
+++ b/library/eos_vrrp.py
@@ -221,6 +221,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -239,7 +283,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -262,6 +306,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -292,9 +339,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -349,6 +393,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -427,7 +474,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')
@@ -493,7 +542,6 @@ class EosAnsibleModule(AnsibleModule):
         cls.stateful_args['state']['choices'].append(name)
 
 #<<EOS_COMMON_MODULE_END>>
-
 
 def instance(module):
     """ Returns an instance of Vrrp based on interface and vrid

--- a/library/eos_vxlan.py
+++ b/library/eos_vxlan.py
@@ -330,7 +330,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -348,6 +347,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_vxlan.py
+++ b/library/eos_vxlan.py
@@ -317,7 +317,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -330,6 +330,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -347,7 +348,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_vxlan.py
+++ b/library/eos_vxlan.py
@@ -143,6 +143,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -161,7 +205,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -184,6 +228,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -214,9 +261,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -271,6 +315,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -349,7 +396,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_vxlan_vlan.py
+++ b/library/eos_vxlan_vlan.py
@@ -282,7 +282,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -295,6 +295,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -312,7 +313,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_vxlan_vlan.py
+++ b/library/eos_vxlan_vlan.py
@@ -295,7 +295,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -313,6 +312,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 

--- a/library/eos_vxlan_vlan.py
+++ b/library/eos_vxlan_vlan.py
@@ -108,6 +108,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -126,7 +170,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -149,6 +193,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -179,9 +226,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -236,6 +280,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -314,7 +361,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_vxlan_vtep.py
+++ b/library/eos_vxlan_vtep.py
@@ -281,7 +281,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.refresh()
                 # After a create command, flush the running-config
                 # so we get the latest for any other attributes
-                self._node.refresh()
+                self._node._running_config = None
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -294,6 +294,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
+            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -311,7 +312,8 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
-        self.result['instance'] = self.instance
+        if self._debug:
+            self.result['instance'] = self.instance
 
         if self.exit_after_flush:
             self.exit()

--- a/library/eos_vxlan_vtep.py
+++ b/library/eos_vxlan_vtep.py
@@ -107,6 +107,50 @@ DEFAULT_SYSLOG_PRIORITY = syslog.LOG_NOTICE
 DEFAULT_CONNECTION = 'localhost'
 TRANSPORTS = ['socket', 'http', 'https', 'http_local']
 
+class EosConnection(object):
+
+    __attributes__ = ['username', 'password', 'host', 'transport', 'port']
+
+    def __init__(self, **kwargs):
+        self.connection = kwargs['connection']
+        self.transport = kwargs.get('transport')
+
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
+
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+
+        self.config = kwargs.get('config')
+
+    def connect(self):
+        if self.config is not None:
+            pyeapi.load_config(self.config)
+
+        config = dict()
+
+        if self.connection is not None:
+            config = pyeapi.config_for(self.connection)
+            if not config:
+                msg = 'Connection name "{}" not found'.format(self.connection)
+
+        for key in self.__attributes__:
+            if getattr(self, key) is not None:
+                config[key] = getattr(self, key)
+
+        if 'transport' not in config:
+            raise ValueError('Connection must define a transport')
+
+        connection = pyeapi.client.make_connection(**config)
+        node = pyeapi.client.Node(connection, **config)
+
+        try:
+            node.enable('show version')
+        except (pyeapi.eapilib.ConnectionError, pyeapi.eapilib.CommandError):
+            raise ValueError('unable to connect to {}'.format(node))
+        return node
+
+
 class EosAnsibleModule(AnsibleModule):
 
     meta_args = {
@@ -125,7 +169,7 @@ class EosAnsibleModule(AnsibleModule):
         'state': dict(default='present', choices=['present', 'absent']),
     }
 
-    def __init__(self, stateful=True, *args, **kwargs):
+    def __init__(self, stateful=True, autorefresh=False, *args, **kwargs):
 
         kwargs['argument_spec'].update(self.meta_args)
 
@@ -148,6 +192,9 @@ class EosAnsibleModule(AnsibleModule):
 
         self._attributes = self.map_argument_spec()
         self.validate()
+        self._autorefresh = autorefresh
+        self._node = EosConnection(**self.params)
+        self._node.connect()
 
         self._node = self.connect()
         self._instance = None
@@ -178,9 +225,6 @@ class EosAnsibleModule(AnsibleModule):
 
     @property
     def node(self):
-        if self._node:
-            return self._node
-        self._node = self.connect()
         return self._node
 
     def check_pyeapi(self):
@@ -235,6 +279,9 @@ class EosAnsibleModule(AnsibleModule):
                 changed = self.create()
                 self.result['changed'] = changed or True
                 self.refresh()
+                # After a create command, flush the running-config
+                # so we get the latest for any other attributes
+                self._node.refresh()
 
             changeset = self.attributes.viewitems() - self.instance.viewitems()
 
@@ -313,7 +360,9 @@ class EosAnsibleModule(AnsibleModule):
             self.fail('Connection must define a transport')
 
         connection = pyeapi.client.make_connection(**config)
-        node = pyeapi.client.Node(connection, **config)
+        self.log('Creating connection with autorefresh=%s' % self._autorefresh)
+        node = pyeapi.client.Node(connection, autorefresh=self._autorefresh,
+                                  **config)
 
         try:
             resp = node.enable('show version')

--- a/library/eos_vxlan_vtep.py
+++ b/library/eos_vxlan_vtep.py
@@ -294,7 +294,6 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changes'] = changes
                 self.result['changed'] = True
 
-            self.log(changes)
             self._attributes.update(changes)
 
             flush = self.func('flush')
@@ -312,6 +311,9 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['changed'] = changed or True
 
         self.refresh()
+        # By calling self.instance here we trigger another show running-config
+        # all which causes delay.  Only if debug is enabled do we call this
+        # since it will display the latest state of the object.
         if self._debug:
             self.result['instance'] = self.instance
 


### PR DESCRIPTION
This PR adds new knob to the eos.py common code.  It exposes an ``autorefresh`` arg in all modules. This arg toggles the underlying pyeapi autorefresh setting on the node connection.  By disabling the autorefresh, we don't perform superfluous 'show run all' (this saves a lot of time with modules that have many attributes).  The only time we force the refresh() method is after the create method is run.  This is so we can get a proper view of the instance after creation.

An example of improvement is the eos_bgp_config:
(tested on a real 7050 with 100+ms RTT)

DEVELOP BRANCH
```
(ansible)phil:misc phil$ time ansible-playbook -i hosts demo-bgp.yml 

PLAY [co157] ****************************************************************** 

TASK: [Configure BGP] ********************************************************* 
changed: [co157]

PLAY RECAP ******************************************************************** 
co157                      : ok=1    changed=1    unreachable=0    failed=0   

real	0m39.560s
user	0m0.369s
sys	0m0.198s
```

THIS BRANCH
```
(ansible)phil:misc phil$ time ansible-playbook -i hosts demo-bgp.yml 

PLAY [co157] ****************************************************************** 

TASK: [Configure BGP] ********************************************************* 
changed: [co157]

PLAY RECAP ******************************************************************** 
co157                      : ok=1    changed=1    unreachable=0    failed=0   

real	0m17.118s
user	0m0.328s
sys	0m0.143s
```

Not bad, better than 2x improvement.  The only module where this doesn't quite work in the port_channel module. For that I set autorefresh=true in the module args.