### PR TITLE
Default interface

### DIFF
--- a/common/eos.py
+++ b/common/eos.py
@@ -86,11 +86,11 @@ class EosAnsibleModule(AnsibleModule):
             kwargs['argument_spec'].update(self.stateful_args)
 
         ## Ok, so in Ansible 2.0,
-        ## AnsibleModule.__init__() sets self.params and then 
+        ## AnsibleModule.__init__() sets self.params and then
         ##   calls self.log()
         ##   (through self._log_invocation())
         ##
-        ## However, self.log() (overridden in EosAnsibleModule) 
+        ## However, self.log() (overridden in EosAnsibleModule)
         ##   references self._logging
         ## and self._logging (defined in EosAnsibleModule)
         ##   references self.params.
@@ -99,7 +99,7 @@ class EosAnsibleModule(AnsibleModule):
         ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
         ##
         ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
-        ## The only caveat is that the first log message in 
+        ## The only caveat is that the first log message in
         ##   AnsibleModule.__init__() won't be subject to the value of
         ##   self.params['logging'].
         self._logging = kwargs.get('logging')
@@ -233,7 +233,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()

--- a/library/eos_acl_entry.py
+++ b/library/eos_acl_entry.py
@@ -204,6 +204,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -334,7 +352,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -448,7 +467,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_bgp_config.py
+++ b/library/eos_bgp_config.py
@@ -207,6 +207,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -337,7 +355,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -451,7 +470,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_bgp_neighbor.py
+++ b/library/eos_bgp_neighbor.py
@@ -231,6 +231,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -361,7 +379,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -475,7 +494,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_bgp_network.py
+++ b/library/eos_bgp_network.py
@@ -172,6 +172,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -302,7 +320,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -416,7 +435,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_command.py
+++ b/library/eos_command.py
@@ -163,6 +163,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -293,7 +311,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -407,7 +426,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_config.py
+++ b/library/eos_config.py
@@ -197,6 +197,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -327,7 +345,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -441,7 +460,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_ethernet.py
+++ b/library/eos_ethernet.py
@@ -209,6 +209,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -339,7 +357,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -453,7 +472,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_facts.py
+++ b/library/eos_facts.py
@@ -173,6 +173,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -303,7 +321,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -417,7 +436,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_interface.py
+++ b/library/eos_interface.py
@@ -46,7 +46,9 @@ requirements:
 notes:
   - All configuration is idempotent unless otherwise specified
   - Supports eos metaparameters for using the eAPI transport
-  - Supports stateful resource configuration.
+  - Supports stateful resource configuration. This method also supports the
+    'default' state. This will default the specified interface. Note however
+    that the default state operation is NOT idempotent.
 options:
   name:
     description:
@@ -451,6 +453,13 @@ def create(module):
     name = module.attributes['name']
     module.log('Invoked create for eos_interface[%s]' % name)
     module.node.api('interfaces').create(name)
+
+def default(module):
+    """Defaults an existing interface from the node
+    """
+    name = module.attributes['name']
+    module.log('Invoked default for eos_interface[%s]' % name)
+    module.node.api('interfaces').default(name)
 
 def remove(module):
     """Removes an existing interface from the node

--- a/library/eos_interface.py
+++ b/library/eos_interface.py
@@ -178,6 +178,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -308,7 +326,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -422,7 +441,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_ipinterface.py
+++ b/library/eos_ipinterface.py
@@ -181,6 +181,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -311,7 +329,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -425,7 +444,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_mlag_config.py
+++ b/library/eos_mlag_config.py
@@ -198,6 +198,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -328,7 +346,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -442,7 +461,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_mlag_interface.py
+++ b/library/eos_mlag_interface.py
@@ -167,6 +167,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -297,7 +315,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -411,7 +430,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_ping.py
+++ b/library/eos_ping.py
@@ -176,6 +176,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -306,7 +324,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -420,7 +439,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_portchannel.py
+++ b/library/eos_portchannel.py
@@ -208,6 +208,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -338,7 +356,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -452,7 +471,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_routemap.py
+++ b/library/eos_routemap.py
@@ -206,6 +206,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -336,7 +354,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -450,7 +469,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_staticroute.py
+++ b/library/eos_staticroute.py
@@ -187,6 +187,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -317,7 +335,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -431,7 +450,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_stp_interface.py
+++ b/library/eos_stp_interface.py
@@ -189,6 +189,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -319,7 +337,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -433,7 +452,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_switchport.py
+++ b/library/eos_switchport.py
@@ -223,6 +223,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -353,7 +371,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -467,7 +486,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_system.py
+++ b/library/eos_system.py
@@ -163,6 +163,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -293,7 +311,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -407,7 +426,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_user.py
+++ b/library/eos_user.py
@@ -241,6 +241,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -371,7 +389,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -485,7 +504,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_varp.py
+++ b/library/eos_varp.py
@@ -149,6 +149,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -279,7 +297,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -393,7 +412,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_varp_interface.py
+++ b/library/eos_varp_interface.py
@@ -163,6 +163,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -293,7 +311,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -407,7 +426,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_vlan.py
+++ b/library/eos_vlan.py
@@ -190,6 +190,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -320,7 +338,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -434,7 +453,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_vrrp.py
+++ b/library/eos_vrrp.py
@@ -291,6 +291,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -421,7 +439,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -535,7 +554,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_vxlan.py
+++ b/library/eos_vxlan.py
@@ -213,6 +213,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -343,7 +361,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -457,7 +476,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_vxlan_vlan.py
+++ b/library/eos_vxlan_vlan.py
@@ -178,6 +178,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -308,7 +326,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -422,7 +441,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/library/eos_vxlan_vtep.py
+++ b/library/eos_vxlan_vtep.py
@@ -177,6 +177,24 @@ class EosAnsibleModule(AnsibleModule):
         if stateful:
             kwargs['argument_spec'].update(self.stateful_args)
 
+        ## Ok, so in Ansible 2.0,
+        ## AnsibleModule.__init__() sets self.params and then
+        ##   calls self.log()
+        ##   (through self._log_invocation())
+        ##
+        ## However, self.log() (overridden in EosAnsibleModule)
+        ##   references self._logging
+        ## and self._logging (defined in EosAnsibleModule)
+        ##   references self.params.
+        ##
+        ## So ... I'm defining self._logging without "or self.params['logging']"
+        ##   *before* AnsibleModule.__init__() to avoid a "ref before def".
+        ##
+        ## I verified that this works with Ansible 1.9.4 and 2.0.0.2.
+        ## The only caveat is that the first log message in
+        ##   AnsibleModule.__init__() won't be subject to the value of
+        ##   self.params['logging'].
+        self._logging = kwargs.get('logging')
         super(EosAnsibleModule, self).__init__(*args, **kwargs)
 
         self.result = dict(changed=False, changes=dict())
@@ -307,7 +325,8 @@ class EosAnsibleModule(AnsibleModule):
 
         elif self._stateful:
             if self.desired_state != self.instance.get('state'):
-                changed = self.invoke(self.instance.get('state'))
+                func = self.func(self.desired_state)
+                changed = self.invoke(func, self)
                 self.result['changed'] = changed or True
 
         self.refresh()
@@ -421,7 +440,7 @@ class EosAnsibleModule(AnsibleModule):
                 self.result['debug'] = dict()
             self.result['debug'][key] = value
 
-    def log(self, message, priority=None):
+    def log(self, message, log_args=None, priority=None):
         if self._logging:
             syslog.openlog('ansible-eos')
             priority = priority or DEFAULT_SYSLOG_PRIORITY

--- a/test/testcases/eos_interface.yaml
+++ b/test/testcases/eos_interface.yaml
@@ -16,6 +16,7 @@ testcases:
       - no interface Loopback0
 
   - name: default loopback0 interface
+    idempotent: false
     arguments:
       - { name: name, value: Loopback0 }
       - { name: state, value: default }
@@ -25,6 +26,7 @@ testcases:
       - interface Loopback0
 
   - name: default Ethernet1 interface
+    idempotent: false
     arguments:
       - { name: name, value: Ethernet1 }
       - { name: state, value: default }
@@ -35,6 +37,7 @@ testcases:
       - description testdesc
 
   - name: default Port-Channel1 interface
+    idempotent: false
     arguments:
       - { name: name, value: Port-Channel1 }
       - { name: state, value: default }

--- a/test/testcases/eos_interface.yaml
+++ b/test/testcases/eos_interface.yaml
@@ -15,6 +15,35 @@ testcases:
     setup:
       - no interface Loopback0
 
+  - name: default loopback0 interface
+    arguments:
+      - { name: name, value: Loopback0 }
+      - { name: state, value: default }
+      - { name: connection, value: $host }
+      - { name: debug, value: true }
+    setup:
+      - interface Loopback0
+
+  - name: default Ethernet1 interface
+    arguments:
+      - { name: name, value: Ethernet1 }
+      - { name: state, value: default }
+      - { name: connection, value: $host }
+      - { name: debug, value: true }
+    setup:
+      - interface Ethernet1
+      - description testdesc
+
+  - name: default Port-Channel1 interface
+    arguments:
+      - { name: name, value: Port-Channel1 }
+      - { name: state, value: default }
+      - { name: connection, value: $host }
+      - { name: debug, value: true }
+    setup:
+      - interface Port-Channel1
+      - description testdesc
+
   - name: delete interface
     arguments:
       - { name: name, value: Loopback0 }


### PR DESCRIPTION
Fix #73 
This PR fixes the logic in eos.py to call methods inside the module code which are non-standard.  By default we can look for present and absent which get mapped to create and remove, respectively.  This enhancement allows you to specify other states in your playbook like 'default' and then implement a default method in your module code.

More specifically, this was always supposed to work but has been broken. Issue #73 brought this to light.